### PR TITLE
Продолжаем вёрстку с препроцессором

### DIFF
--- a/source/less/fonts.less
+++ b/source/less/fonts.less
@@ -7,13 +7,3 @@
   font-style: normal;
   font-display: swap;
 }
-
-@font-face {
-  font-family: "Oswald";
-  src:
-    url("../fonts/oswaldmedium.woff2") format("woff2"),
-    url("../fonts/oswaldmedium.woff") format("woff");
-  font-weight: 500;
-  font-style: normal;
-  font-display: swap;
-}


### PR DESCRIPTION
Убран шрифт только Oswald-medium, т.к он нигде не используется. Верну когда он встретится в макетах.

Все остальное сделано в предыдущей итерации.

---
:mortar_board: [Продолжаем вёрстку с препроцессором](https://up.htmlacademy.ru/adaptive/19/user/1339161/tasks/7)